### PR TITLE
鬼道《Hybrid API》，slide在我github pages上，所以直接跳转

### DIFF
--- a/slides/luics-hybrid-api.html
+++ b/slides/luics-hybrid-api.html
@@ -1,0 +1,1 @@
+<html><script>location.href='http://luics.github.io/demo/hybrid-api/hangjs/';</script></html>


### PR DESCRIPTION
这是《Hybrid API》的slide地址 http://luics.github.io/demo/hybrid-api/hangjs/ 
所以写了js跳转
